### PR TITLE
Made vbar build again

### DIFF
--- a/gtk.go
+++ b/gtk.go
@@ -69,10 +69,7 @@ type Rectangle struct {
 }
 
 func getMonitorDimensions(window *gtk.Window) (Rectangle, error) {
-	screen, err := window.GetScreen()
-	if err != nil {
-		return Rectangle{}, err
-	}
+	screen := window.GetScreen()
 	display, err := screen.GetDisplay()
 	if err != nil {
 		return Rectangle{}, err
@@ -130,10 +127,7 @@ func popupMenuAt(widget *gtk.Widget, menu *gtk.Menu) {
 }
 
 func enableTransparency(window *gtk.Window) error {
-	screen, err := window.GetScreen()
-	if err != nil {
-		return err
-	}
+	screen := window.GetScreen()
 
 	visual, err := screen.GetRGBAVisual()
 	if err != nil {

--- a/window.go
+++ b/window.go
@@ -109,12 +109,9 @@ func (w *Window) addCSS(addCSS AddCSS) error {
 	}
 
 	return executeGtkSync(func() error {
-		screen, err := window.gtkWindow.GetScreen()
-		if err != nil {
-			return err
-		}
+		screen := window.gtkWindow.GetScreen()
 
-		err = w.cssApplier.Apply(screen, addCSS)
+		err := w.cssApplier.Apply(screen, addCSS)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Closes issue #18. The bug was caused by gtk.window.GetScreen() going from returning 2 arguments to just one.